### PR TITLE
Feature/allow nested aws keys windows

### DIFF
--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -61,7 +61,7 @@ var decryptCmd = &cobra.Command{
 				if !strings.HasSuffix(m.Files[i].Name, "manifest.json") {
 					wg.Add(1)
 
-					f := utils.OsGnostic_HandleAwsKey(org, folder, m.Files[i].Name + ".zip.gpg")
+					f := utils.OsAgnostic_HandleAwsKey(org, folder, m.Files[i].Name + ".zip.gpg")
 
 					go func(f string, opts options.Options) {
 						defer wg.Done()

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -70,11 +70,12 @@ var decryptCmd = &cobra.Command{
 				}
 			}
 			wg.Wait()
+			utils.CleanupDirectory(opts.Destination + m.Folder)
+
 		} else {
 			decryptFile(opts.File, opts)
 		}
 		timing(start, "Elapsed time: %f")
-		utils.CleanupDirectory(opts.Destination + m.Folder)
 	},
 }
 

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -49,6 +49,7 @@ that it will be encrypted.`,
 		checkShareOptions(opts)
 		fnuuid, _ := uuid.NewV4()
 		folder := opts.Prefix + "_s3s2_" + fnuuid.String()
+
 		m := manifest.BuildManifest(folder, opts)
 
 		if err := s3helper.UploadFile(folder, opts.Directory+m.Name, opts); err != nil {

--- a/s3/s3helper.go
+++ b/s3/s3helper.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	options "github.com/jemurai/s3s2/options"
 	log "github.com/sirupsen/logrus"
+	utils "github.com/jemurai/s3s2/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -47,10 +47,13 @@ func UploadFile(folder string, filename string, options options.Options) error {
 		return fmt.Errorf("failed to open file %q, %v", filename, err)
 	}
 
+	basename := filepath.Base(f.Name())
+	aws_key := utils.OsGnostic_HandleAwsKey(options.Org, folder, basename)
+
 	if options.AwsKey != "" {
 		result, err := uploader.Upload(&s3manager.UploadInput{
 			Bucket:               aws.String(options.Bucket),
-			Key:                  aws.String(filepath.Clean(folder + "/" + strings.Replace(f.Name(), options.Directory, "", -1))),
+			Key:                  aws.String(aws_key),
 			ServerSideEncryption: aws.String("aws:kms"),
 			SSEKMSKeyId:          aws.String(options.AwsKey),
 			Body:                 f,
@@ -62,7 +65,7 @@ func UploadFile(folder string, filename string, options options.Options) error {
 	} else {
 		result, err := uploader.Upload(&s3manager.UploadInput{
 			Bucket: aws.String(options.Bucket),
-			Key:    aws.String(filepath.Clean(folder + "/" + strings.Replace(f.Name(), options.Directory, "", -1))),
+			Key:    aws.String(aws_key),
 			Body:   f,
 		})
 		if err != nil {

--- a/s3/s3helper.go
+++ b/s3/s3helper.go
@@ -48,7 +48,7 @@ func UploadFile(folder string, filename string, options options.Options) error {
 	}
 
 	basename := filepath.Base(f.Name())
-	aws_key := utils.OsGnostic_HandleAwsKey(options.Org, folder, basename)
+	aws_key := utils.OsAgnostic_HandleAwsKey(options.Org, folder, basename)
 
 	if options.AwsKey != "" {
 		result, err := uploader.Upload(&s3manager.UploadInput{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -25,3 +26,9 @@ func CleanupDirectory(fn string) {
 		log.Debugf("\tCleaned up: %s", fn)
 	}
 }
+
+
+func OsGnostic_HandleAwsKey(org string, folder string, fn string) string {
+	return filepath.ToSlash(filepath.Clean(filepath.Join(org, folder, fn)))
+}
+

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,7 +28,7 @@ func CleanupDirectory(fn string) {
 }
 
 
-func OsGnostic_HandleAwsKey(org string, folder string, fn string) string {
+func OsAgnostic_HandleAwsKey(org string, folder string, fn string) string {
 	return filepath.ToSlash(filepath.Clean(filepath.Join(org, folder, fn)))
 }
 


### PR DESCRIPTION
ticket: 
https://tempuslabs.atlassian.net/browse/NI-1292

notes:
- witnessed occurences of utils.cleanups not working because target files were still in use, chose not to address this problem in this ticket
- added utility to format aws strings regardless of operating system
- previously, reading files from manifest was breaking because it wasn't reconstructing the entire path - this is now fixed

tested on local mac and windows ec2 instance