### PR TITLE
Fix Jenkins publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
     stages {
         stage('build') {
             steps {
-                sh script: "chmod u+x ./deploy_build.sh", label: "Permissioning build file..."
                 sh script: "./deploy_build.sh", label: "Building..."
                 sh script: 'echo Built successfully!', label: "Build successful!"
                 }
@@ -23,8 +22,8 @@ pipeline {
                 NEXUS_PATH = 'https://nexus.securetempus.com/repository/tempus-n'
             }
             steps {
-                // Fun stuff it **** anything similar to NEXUS_CREDS
-                sh script:'echo $NEXUS_CREDS_USR should be leeroy-tempus-n if this worked :pray:', label: "Checking creds"
+                // Fun stuff it will mask out with **** anything similar to NEXUS_CREDS
+                // ${GIT_COMMIT} is the commit hash if you want to use that
                 sh script: 'curl --fail --user "${NEXUS_CREDS}" --upload-file ./linux/s3s2-linux-amd64 ${NEXUS_PATH}/s3s2-linux-amd64', label: "Publishing Linux build"
                 sh script: 'curl --fail --user "${NEXUS_CREDS}" --upload-file ./darwin/s3s2-darwin-amd64 ${NEXUS_PATH}/s3s2-darwin-amd64', label: "Publishing Mac build"
                 sh script: 'curl --fail --user "${NEXUS_CREDS}" --upload-file ./windows/s3s2-windows-amd64.exe ${NEXUS_PATH}/s3s2-windows-amd64.exe', label: "Publishing Windows build"

--- a/deploy_build.sh
+++ b/deploy_build.sh
@@ -11,6 +11,6 @@ echo "Installing from local Go mod..."
 GOCACHE=$WORKSPACE go mod download
 
 echo "Building for operating systems..."
-GOOS=linux GOARCH=amd64 GOCACHE=$WORKSPACE go build -o linux/s3s2-linux-amd64 -v &
-GOOS=darwin GOARCH=amd64 GOCACHE=$WORKSPACE go build -o darwin/s3s2-darwin-amd64 -v &
-GOOS=windows GOARCH=amd64 GOCACHE=$WORKSPACE go build -o windows/s3s2-windows-amd64.exe -v &
+GOOS=linux GOARCH=amd64 GOCACHE=$WORKSPACE go build -o linux/s3s2-linux-amd64 -v
+GOOS=darwin GOARCH=amd64 GOCACHE=$WORKSPACE go build -o darwin/s3s2-darwin-amd64 -v
+GOOS=windows GOARCH=amd64 GOCACHE=$WORKSPACE go build -o windows/s3s2-windows-amd64.exe -v


### PR DESCRIPTION
* deploy_build.sh was backgrounding the compile step, so depending how
speedy things were the curl out to Nexus would fail because the build
was not complete yet. If the day comes where we really need to save
minutes by compiling the targets in parallel we can do that in parallel
Jenkins steps I believe.

* chmod the deploy_build.sh in the repo itself instead of every build