### PR TITLE
NI-8950: Ensure uppercase organization for uploads and downloads

### DIFF
--- a/aws_helpers/s3helper.go
+++ b/aws_helpers/s3helper.go
@@ -26,7 +26,7 @@ func UploadFile(sess *session.Session, org string, aws_key string, local_path st
         file, err := os.Open(local_path)
         utils.PanicIfError("Failed to open file for upload - ", err)
 
-        final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(org, aws_key)))
+        final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(strings.ToUpper(org), aws_key)))
         log.Debugf("Uploading file '%s' to aws key '%s'", local_path, final_key)
 
         for {
@@ -76,7 +76,7 @@ func UploadLambdaTrigger(sess *session.Session, org string, folder string, opts 
 
         file_name := "._lambda_trigger"
 
-        final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(org, folder, file_name)))
+        final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(strings.ToUpper(org), folder, file_name)))
         log.Debugf("Uploading file '%s' to aws key '%s'", file_name, final_key)
 
         if opts.AwsKey != "" {
@@ -113,7 +113,7 @@ func DownloadFile(sess *session.Session, bucket string, org string, aws_key stri
         file, err := os.Create(target_path)
         utils.PanicIfError("Unable to open file - ", err)
 
-        final_key := filepath.Join(org, aws_key)
+        final_key := filepath.Join(strings.ToUpper(org), aws_key)
 
         log.Infof("Downloading from key '%s' to file '%s'", final_key, target_path)
 

--- a/gcp_helpers/gcshelper.go
+++ b/gcp_helpers/gcshelper.go
@@ -7,6 +7,7 @@ import (
     "path/filepath"
 	"io"
 	"io/ioutil"
+	"strings"
 	"google.golang.org/api/option"
 	log "github.com/sirupsen/logrus"
 	options "github.com/tempuslabs/s3s2/options"
@@ -33,7 +34,7 @@ func UploadFile(org string, aws_key string, local_path string, opts options.Opti
 
     utils.PanicIfError("Failed to open file for upload - ", err)
 
-    final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(org, aws_key)))
+    final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(strings.ToUpper(org), aws_key)))
     log.Debugf("Uploading file '%s' to aws key '%s'", local_path, final_key)
 
    
@@ -67,7 +68,7 @@ func UploadLambdaTrigger(org string, folder string, opts options.Options) error 
 	file, err := os.Create(file_name)
 	defer file.Close()
 	bucket := opts.Bucket
-    final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(org, folder, file_name)))
+    final_key := utils.ToPosixPath(filepath.Clean(filepath.Join(strings.ToUpper(org), folder, file_name)))
     log.Debugf("Uploading file '%s' to bucket '%s' aws key '%s'", file_name, bucket, final_key)
 	wc := client.Bucket(bucket).Object(final_key).NewWriter(ctx)
 	defer wc.Close()
@@ -88,7 +89,7 @@ func DownloadFile(bucket string, org string, aws_key string, target_path string)
 	client, err := storage.NewClient(ctx, option.WithCredentialsFile(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")))
 	utils.PanicIfError("Unable to get context client - ", err)
 
-	final_key := filepath.Join(org, aws_key)
+	final_key := filepath.Join(strings.ToUpper(org), aws_key)
 
 	rc, err := client.Bucket(bucket).Object(final_key).NewReader(ctx)
 	utils.PanicIfError("Unable to get object - ", err)


### PR DESCRIPTION
Files used to test - [s3s2_testing.zip](https://github.com/tempuslabs/s3s2/files/9046920/s3s2_testing.zip)

Commands:
```
s3s2 share \
--config /Users/brandon.vogt/s3s2-demo.json \
--directory /Users/brandon.vogt/scratch/temp \
--region "us-west-2" \
--org "PacCC_392" \
--receiver-public-key "/Users/brandon.vogt/scratch/key_public.gpg"
```

```
s3s2 decrypt \
--debug True \
--region "us-west-2" \
--directory "/Users/brandon.vogt/scratch/temp/return" \
--bucket "tempus-n-data-pipeline-staging-usw2" \
--file "PACCC_392/testing_clinical_s3s2_20220704233754_0/s3s2_manifest.json" \
--my-private-key "/Users/brandon.vogt/scratch/key.gpg" \
--my-public-key "/Users/brandon.vogt/scratch/key_public.gpg" \
--parallelism 15
```

[Result bucket](https://s3.console.aws.amazon.com/s3/object/tempus-n-data-pipeline-staging-usw2?region=us-west-2&prefix=PACCC_392/testing_clinical_s3s2_20220704233754_0/s3s2_manifest.json) -- note the uppercase org folder despite mixed case org declaration. Additionally, decrypt works despite mixed case "Organization" in s3s2_manifest.json.
